### PR TITLE
Replace version separator with space

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -32,6 +32,6 @@ keys=$(for ix in ${!tags_weight[*]}; do
 done | sort -V | cut -d+ -f2)
 
 for ix in ${keys}; do
-    printf "%s\n" ${tags_orig[${ix}]}
+    printf "%s " ${tags_orig[${ix}]}
 done
 


### PR DESCRIPTION
When I trying to list all versions for Scala, it shows oldest version only like below:

![image](https://user-images.githubusercontent.com/6194958/82985097-62845180-a02e-11ea-9c08-e01192e0926c.png)

From [latest asdf document](https://asdf-vm.com/#/plugins-create?id=binlist-all) says,

**bin/list-all**
> Must print a string with a space-separated list of versions.

## Changes

- Replace version separator(newline character) with space