### PR TITLE
add support for scala 3

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -70,9 +70,16 @@ get_download_url() {
   local install_type=$1
   local version=$2
 
-  local download_page="https://scala-lang.org/download/$version.html"
-  local download_url="$(curl -s $download_page | grep 'link-main-unixsys' | sed -E 's/(.*)(href=")(.*)(">)/\3/g')"
-  echo $download_url
+  case "$version" in
+    3.*)
+      echo "https://github.com/lampepfl/dotty/releases/download/$version/scala3-$version.tar.gz"
+      ;;
+    *)
+      local download_page="https://scala-lang.org/download/$version.html"
+      local download_url="$(curl -s $download_page | grep 'link-main-unixsys' | sed -E 's/(.*)(href=")(.*)(">)/\3/g')"
+      echo $download_url
+      ;;
+  esac
 }
 
 install_scala $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
Scala 3 has now been released, and it is reported as the latest version:

```
$ asdf latest scala
3.0.0
```

however, it needs to be download from a different path, on the [download page](https://www.scala-lang.org/download/scala3.html) they have switched to downloads via github releases:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/2242307/118799933-3b560e00-b897-11eb-97be-a6708a3050f3.png">

This PR adds support for downloading version 3.
